### PR TITLE
Delay creating a temp directory until assets are actually written

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -9,3 +9,7 @@ Birthday!
 == 1.1.0
 
 * Removing config check causing assets to not get compiled in production.
+
+== 1.1.1
+
+* Delay creating a temp directory until assets are actually written.

--- a/lib/generated-assets.rb
+++ b/lib/generated-assets.rb
@@ -1,6 +1,5 @@
 # encoding: UTF-8
 
-require 'fileutils'
 require 'generated-assets/railtie'
 require 'securerandom'
 require 'tmpdir'
@@ -14,9 +13,7 @@ module GeneratedAssets
   class << self
     def asset_dir
       @asset_dir ||= begin
-        dir = File.join(Dir.tmpdir, SecureRandom.hex)
-        FileUtils.mkdir_p(dir)
-        dir
+        File.join(Dir.tmpdir, SecureRandom.hex)
       end
     end
   end

--- a/lib/generated-assets/manifest.rb
+++ b/lib/generated-assets/manifest.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 
+require 'fileutils'
+
 module GeneratedAssets
   class Manifest
     attr_reader :app, :prefix, :entries
@@ -37,9 +39,15 @@ module GeneratedAssets
     private
 
     def write_files
+      ensure_prefix_dir_exists unless entries.empty?
+
       entries.each do |entry|
         entry.write_to(prefix)
       end
+    end
+
+    def ensure_prefix_dir_exists
+      FileUtils.mkdir_p(prefix)
     end
 
     def add_precompile_paths

--- a/lib/generated-assets/version.rb
+++ b/lib/generated-assets/version.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
 
 module GeneratedAssets
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
Should cut down on the number of directories created in /tmp.
