### PR TITLE
New logic for assets_dir filename

### DIFF
--- a/lib/generated-assets.rb
+++ b/lib/generated-assets.rb
@@ -13,7 +13,13 @@ module GeneratedAssets
   class << self
     def asset_dir
       @asset_dir ||= begin
-        File.join(Dir.tmpdir, SecureRandom.hex)
+        locales_dir = "#{::Rails.root}/config/locales"
+        locales = Dir.entries(locales_dir).select {|locale| File.extname(locale) == ".yml"}
+        mtime_paths = locales.map do |locale|
+          mtime = File.mtime("#{locales_dir}/#{locale}")
+        end
+        dir_name = mtime_paths.join("")
+        File.join(Dir.tmpdir, Digest::SHA256.new.hexdigest(dir_name))
       end
     end
   end


### PR DESCRIPTION
Change it to be dependent on i18n assets instead of being randomly generated.

This helps address a caching bug that forces most assets to be rebuilt upon launching rails.

The generated_assets directory is added to app.config.assets.paths.
In sprockets, it defines the list of dependencies for "environment-paths" -
That means that any asset that has "environment-paths" as a dependency depends on the assets_dir directory.
Most rails assets end up depending on "environment-paths".
If one of the directories in that dependency list changes, the asset has to be rebuilt.
A random directory name forces asset rebuilding on each rails launch, and a static path name doesn't detect i18n assets getting changed.
To address both use cases, generate the directory name based on the mtimes of the internationalization .yml files.
