### PR TITLE
assets_dir: change it to be static instead of being randomly generated

### DIFF
--- a/lib/generated-assets.rb
+++ b/lib/generated-assets.rb
@@ -13,7 +13,7 @@ module GeneratedAssets
   class << self
     def asset_dir
       @asset_dir ||= begin
-        File.join(Dir.tmpdir, SecureRandom.hex)
+        File.join(Dir.tmpdir, "generated-assets")
       end
     end
   end


### PR DESCRIPTION
This helps address a caching bug that forces most assets to be rebuilt upon launching rails.
The generated_assets directory is added to app.config.assets.paths.
In sprockets, it defines the list of dependencies for "environment-paths" -
That means that any asset that has "environment-paths" as a dependency depends on the assets_dir directory.
Most rails assets end up depending on "environment-paths".
If one of the directories in that dependency list changes, the asset has to be rebuilt.
A random directory name forces asset rebuilding on each rails launch.

A static directory name avoid unnecessery asset recompilation.
Forcing recompilation is left as a responsibility for gems further down the chain
