### PR TITLE
Use module_parent_name in Rails >= 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,3 +52,10 @@ matrix:
     env: RAILS_VERSION=5.2
   - rvm: 2.6.0
     env: RAILS_VERSION=5.2
+
+  - rvm: 2.5.8
+    env: RAILS_VERSION=6.0
+  - rvm: 2.6.6
+    env: RAILS_VERSION=6.0
+  - rvm: 2.7.1
+    env: RAILS_VERSION=6.0

--- a/lib/generated-assets/railtie.rb
+++ b/lib/generated-assets/railtie.rb
@@ -21,11 +21,20 @@ module GeneratedAssets
 
   module RailtieHelper
     def self.app_name_for(app)
-      case app
-        when Class               # rails 5
-          app.parent_name
-        else
-          app.class.parent_name  # rails 3, 4
+      if ::Rails::VERSION::MAJOR >= 6
+        case app
+          when Class
+            app.module_parent_name
+          else
+            app.class.module_parent_name
+        end
+      else
+        case app
+          when Class               # rails 5
+            app.parent_name
+          else
+            app.class.parent_name  # rails 3, 4
+        end
       end
     end
   end


### PR DESCRIPTION
This fixes a deprecation warning for `parent_name` in Rails 6.

I wasn't sure what to do with the `# rails 5`, `# rails 3, 4` comments, since it seems like both get used when I test on Rails 6, so I just didn't copy them over.