### PR TITLE
Add more Ruby and Rails versions to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,11 @@ matrix:
     env: RAILS_VERSION=5.1.0
   - rvm: 2.6.6
     env: RAILS_VERSION=5.2.0
-  - rvm: 2.7.1
+  - rvm: 2.7.7
     env: RAILS_VERSION=6.0.0
+  - rvm: 2.7.7
+    env: RAILS_VERSION=6.1.0
+  - rvm: 3.0.4
+    env: RAILS_VERSION=7.0.0
+  - rvm: 3.2.1
+    env: RAILS_VERSION=7.0.0


### PR DESCRIPTION
Hi! I am interested in this gem, and was wondering if there are any issues with newer versions of Ruby and Rails. I've just made some small tweaks to the build matrix to add some newer versions. I tried to follow the format that was previously used (e.g. I used x.0.0 versions of Rails rather than listing the exact latest versions, since it probably shouldn't matter). I did bump the Ruby patch version for 6.0 though.

Adding Rails 6.1, 7.0, and Ruby 3.0 and 3.2. Not sure if 3.1 would be useful to add as well, but I didn't see a lot of multiple Ruby versions with multiple Rails versions so I erred on the side of not adding it for now.

Thank you!